### PR TITLE
Multi Line Meta Descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ node_modules
 .cache/
 public/
 .DS_Store
-yarn-error.log
+yarn*
 .env*
 npm-debug.log
 package-lock.json

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -31,7 +31,7 @@ class SEO extends Component {
       description =
         postNode.metaDescription === null
           ? postNode.body.childMarkdownRemark.excerpt
-          : postNode.metaDescription
+          : postNode.metaDescription.internal.content
 
       pageUrl = config.siteUrl + '/' + pagePath + '/'
     }

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -30,7 +30,11 @@ export const query = graphql`
     contentfulPage(slug: { eq: $slug }) {
       title
       slug
-      metaDescription
+      metaDescription {
+        internal {
+          content
+        }
+      }
       body {
         childMarkdownRemark {
           html

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -52,7 +52,11 @@ export const query = graphql`
       title
       id
       slug
-      metaDescription
+      metaDescription {
+        internal {
+          content
+        }
+      }
       publishDate(formatString: "MMMM DD, YYYY")
       publishDateISO: publishDate(formatString: "YYYY-MM-DD")
       tags {


### PR DESCRIPTION
This PR changes the meta description to long text. It fixes the issue of using a single line field for meta description which became unwieldy for longer descriptions now that the limit has been changed to 320 characters. Contentful short text fields are limited to around 255 characters.

This requires a change to the content model unfortunately. So `export.json` will need to be updated again.

metaDescription should be set as long text, use the same validation, and appearance should be multi-line rather than markdown.

I would also recommend moving Tags and Meta Desciption underneath the Body field so users don't need to scroll to write content. It is also easier to pick tags and write the meta description after the main post is composed.

In addition to this main feature, I made a slight modification to the .gitignore file to keep yarn.lock files out of the repo.