### PR TITLE
Add Client-Side Search

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -161,5 +161,20 @@ module.exports = {
       },
     },
     'gatsby-plugin-netlify',
+    {
+      resolve: `@andrew-codes/gatsby-plugin-elasticlunr-search`,
+      options: {
+        // Fields to index
+        fields: ['title'],
+        // How to resolve each field's value for a supported node type
+        resolvers: {
+          // For any node of type MarkdownRemark, list how to resolve the fields' values
+          ContentfulPost: {
+            title: node => node.title,
+            // description: node => node.description,
+          },
+        },
+      },
+    },
   ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@andrew-codes/gatsby-plugin-elasticlunr-search": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@andrew-codes/gatsby-plugin-elasticlunr-search/-/gatsby-plugin-elasticlunr-search-1.0.4.tgz",
+      "integrity": "sha512-P6RR3oAl1BVNhEZBXst/KEXLi2T2x2D6J6UBwmsgZNf0lLtHL/7N68KeLN+J2VKcAmvDpJ83o2KEj3ft/jND8g==",
+      "requires": {
+        "elasticlunr": "^0.9.5",
+        "graphql": "^0.11.7"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0-beta.44",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
@@ -4374,6 +4383,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "elasticlunr": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/elasticlunr/-/elasticlunr-0.9.5.tgz",
+      "integrity": "sha1-ZVQbswnd3Qz5Ty0ciGGyvmUbsNU="
     },
     "electron-to-chromium": {
       "version": "1.3.52",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2972,9 +2972,9 @@
       }
     },
     "colors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
-      "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.1.tgz",
+      "integrity": "sha512-jg/vxRmv430jixZrC+La5kMbUWqIg32/JsYNZb94+JEmzceYbWKTsv1OuTp+7EaqiaWRR2tPcykibwCRgclIsw==",
       "optional": true
     },
     "combined-stream": {
@@ -3161,14 +3161,14 @@
       }
     },
     "contentful-import": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/contentful-import/-/contentful-import-7.0.4.tgz",
-      "integrity": "sha512-dTyuUuO6xVU8cllSHlu5yszEyX//bu7JuRO+r7Zn9FsfS3dpkqkbmev1wTVL5/tOi6f5V0jsOgfp/9b9ZtH2UA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/contentful-import/-/contentful-import-7.2.0.tgz",
+      "integrity": "sha512-7L/7vkbJkh7698UST92z0gDbkQ11rr9dG9wEQcEdrQjDat2Q4AUwraJhFrXEksXxSUwtsKEPYYqT621/dQu1DQ==",
       "requires": {
         "bluebird": "^3.5.1",
-        "cli-table3": "^0.5.0",
+        "cli-table3": "^0.5.1",
         "contentful-batch-libs": "^9.0.0",
-        "contentful-management": "^5.0.0",
+        "contentful-management": "^5.3.0",
         "echo-cli": "^1.0.8",
         "joi": "^13.4.0",
         "listr": "^0.14.1",
@@ -3180,13 +3180,24 @@
       }
     },
     "contentful-management": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-5.1.4.tgz",
-      "integrity": "sha512-03YJgKemtBhFSmS/pQTsrUWXGCmdTIxGVkEYt7jNvVtSLtXbCzL/5eh4SOqqlXc1E9bex8k8z93p/y6HbtasZQ==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-5.3.2.tgz",
+      "integrity": "sha512-4BsKlKPROb599fKC88//dKabSZ7F0APZryWn2GOHe12Flkhn1R/i1CJELf3Tf3o6guGLf7NSMqrYIQWN3/6ojA==",
       "requires": {
         "@contentful/axios": "^0.18.0",
-        "contentful-sdk-core": "^6.0.0-beta1",
+        "contentful-sdk-core": "^6.0.1",
         "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "contentful-sdk-core": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-6.0.1.tgz",
+          "integrity": "sha512-Rd0jbjmiIbScbothezO08DPkfRrByB0Y4onAWAhthKSXagMBx8oAP9kVvEKJpluc57Rb/slG3NcHuD09bAiWkw==",
+          "requires": {
+            "lodash": "^4.17.10",
+            "qs": "^6.5.2"
+          }
+        }
       }
     },
     "contentful-resolve-response": {
@@ -8615,9 +8626,9 @@
       }
     },
     "hoek": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
-      "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.4.tgz",
+      "integrity": "sha512-Alr4ZQgoMlnere5FZJsIyfIjORBqZll5POhDsF4q64dPuJR6rNxXdDxtHSQq8OXRurhmx+PWYEE8bXRROY8h0w=="
     },
     "hoist-non-react-statics": {
       "version": "2.5.5",
@@ -8897,9 +8908,9 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.0.0.tgz",
-      "integrity": "sha512-tISQWRwtcAgrz+SHPhTH7d3e73k31gsOy6i1csonLc0u1dVK/wYvuOnFeiWqC5OXFIYbmrIFInef31wbT8MEJg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.1.0.tgz",
+      "integrity": "sha512-f9K2MMx/G/AVmJSaZg2a+GVLRRmTdlGLbwxsibNd6yNTxXujqxPypjCnxnC0y4+Wb/rNY5KyKuq06AO5jrE+7w==",
       "requires": {
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.0",
@@ -8935,9 +8946,9 @@
           }
         },
         "external-editor": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.0.tgz",
-          "integrity": "sha512-mpkfj0FEdxrIhOC04zk85X7StNtr0yXnG7zCb+8ikO8OJi2jsHh5YGoknNTyXgsbHOf1WOOcVU3kPFWT2WgCkQ==",
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.1.tgz",
+          "integrity": "sha512-e1neqvSt5pSwQcFnYc6yfGuJD2Q4336cdbHs5VeUO0zTkqPbrHMyw2q1r47fpfLWbvIG8H8A6YO3sck7upTV6Q==",
           "requires": {
             "chardet": "^0.5.0",
             "iconv-lite": "^0.4.22",
@@ -9570,9 +9581,9 @@
       }
     },
     "joi": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-13.4.0.tgz",
-      "integrity": "sha512-JuK4GjEu6j7zr9FuVe2MAseZ6si/8/HaY0qMAejfDFHp7jcH4OKE937mIHM5VT4xDS0q7lpQbszbxKV9rm0yUg==",
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.6.0.tgz",
+      "integrity": "sha512-E4QB0yRgEa6ZZKcSHJuBC+QeAwy+akCG0Bsa9edLqljyhlr+GuGDSmXYW1q7sj/FuAPy+ECUI3evVtK52tVfwg==",
       "requires": {
         "hoek": "5.x.x",
         "isemail": "3.x.x",
@@ -11045,9 +11056,9 @@
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "nanoid": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.1.0.tgz",
-      "integrity": "sha512-iOCqgXieGrk8/wDt1n9rZS2KB1dYVssemY0NTWjfzVr+1t1gAmdTp1u2+YHppKro3Bk5S+Gs+xmYCfpuXauYXQ=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.2.1.tgz",
+      "integrity": "sha512-S1QSG+TQtsqr2/ujHZcNT0OxygffUaUT755qTc/SPKfQ0VJBlOO6qb1425UYoHXPvCZ3pWgMVCuy1t7+AoCxnQ=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -13279,9 +13290,9 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
     "prettier": {
-      "version": "1.13.7",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.7.tgz",
-      "integrity": "sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.2.tgz",
+      "integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==",
       "dev": true
     },
     "pretty-bytes": {
@@ -13748,6 +13759,19 @@
             "signal-exit": "^3.0.2"
           }
         },
+        "sockjs-client": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+          "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+          "requires": {
+            "debug": "^2.6.6",
+            "eventsource": "0.1.6",
+            "faye-websocket": "~0.11.0",
+            "inherits": "^2.0.1",
+            "json3": "^3.3.2",
+            "url-parse": "^1.1.8"
+          }
+        },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -13810,9 +13834,9 @@
       }
     },
     "react-is": {
-      "version": "16.4.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.1.tgz",
-      "integrity": "sha512-xpb0PpALlFWNw/q13A+1aHeyJyLYCg0/cCHPUA43zYluZuIPHaHL3k8OBsTgQtxqW0FhyDEMvi8fZ/+7+r4OSQ=="
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.2.tgz",
+      "integrity": "sha512-rI3cGFj/obHbBz156PvErrS5xc6f1eWyTwyV4mo0vF2lGgXgS+mm7EKD5buLJq6jNgIagQescGSVG2YzgXt8Yg=="
     },
     "react-proxy": {
       "version": "3.0.0-alpha.1",
@@ -14515,16 +14539,16 @@
       }
     },
     "remote-redux-devtools": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/remote-redux-devtools/-/remote-redux-devtools-0.5.12.tgz",
-      "integrity": "sha1-QsuV36nlTB2WcTF8Xnu6QeaMrsI=",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/remote-redux-devtools/-/remote-redux-devtools-0.5.13.tgz",
+      "integrity": "sha512-daDtwkoUEQ9qw4ciFEu0JZzB2NxKHSBrdVSRvrhi9wbwLI4ADiIctsXvkIOwrj0hxcSjDSOzp1WLlv7AJYp++g==",
       "requires": {
         "jsan": "^3.1.5",
         "querystring": "^0.2.0",
-        "redux-devtools-instrument": "^1.3.3",
+        "redux-devtools-instrument": "^1.9.0",
         "remotedev-utils": "^0.1.1",
         "rn-host-detect": "^1.0.1",
-        "socketcluster-client": "^5.3.1"
+        "socketcluster-client": "^13.0.0"
       }
     },
     "remotedev-serialize": {
@@ -14792,9 +14816,9 @@
       }
     },
     "rn-host-detect": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/rn-host-detect/-/rn-host-detect-1.1.4.tgz",
-      "integrity": "sha512-aXPcxgh49BvAveu5PsseQn9M0Eo5/01pVm5sG7fO2kSlTcBkhbUhDmblZrqevqs93HUViRn9naUUo3bxS/3R0Q=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rn-host-detect/-/rn-host-detect-1.1.5.tgz",
+      "integrity": "sha512-ufk2dFT3QeP9HyZ/xTuMtW27KnFy815CYitJMqQm+pgG3ZAtHBsrU8nXizNKkqXGy3bQmhEoloVbrfbvMJMqkg=="
     },
     "rollup": {
       "version": "0.58.2",
@@ -14958,32 +14982,17 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "sc-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.0.6.tgz",
-      "integrity": "sha1-s4vUepk+eCkPvFNGeGf2sqCghjk=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sc-channel/-/sc-channel-1.2.0.tgz",
+      "integrity": "sha512-M3gdq8PlKg0zWJSisWqAsMmTVxYRTpVRqw4CWAdKBgAfVKumFcTjoCV0hYu7lgUXccCtCD8Wk9VkkE+IXCxmZA==",
       "requires": {
-        "sc-emitter": "1.x.x"
-      }
-    },
-    "sc-emitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sc-emitter/-/sc-emitter-1.1.0.tgz",
-      "integrity": "sha1-7xGdQiL0xk+Ie0hpZO8REWzdDnU=",
-      "requires": {
-        "component-emitter": "1.2.0"
-      },
-      "dependencies": {
-        "component-emitter": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.0.tgz",
-          "integrity": "sha1-zNETqGOI0GSC0D3j/H35hSa6jv4="
-        }
+        "component-emitter": "1.2.1"
       }
     },
     "sc-errors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-1.3.3.tgz",
-      "integrity": "sha1-wAvEx2apcMyNWTfQjNWOkx19rgU="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/sc-errors/-/sc-errors-1.4.0.tgz",
+      "integrity": "sha512-h+jRWx/xRJmkPFDd0IltoTl/QJ6hAr5Y+3ZVeBQRLuWZKe+dHdf2uVwFp2OYqlLQ7GHht4y9eXG2zOf2Ik6PTw=="
     },
     "sc-formatter": {
       "version": "3.0.2",
@@ -15401,9 +15410,9 @@
       }
     },
     "shortid": {
-      "version": "2.2.12",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.12.tgz",
-      "integrity": "sha512-sw0knB/ioTu/jVYgJz1IP1b5uhPZtZYwQ9ir/EqXZHI4+Jh8rzzGLM3LKptGHBKoDsgTBDfr4yCRNUX7hEIksQ==",
+      "version": "2.2.13",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.13.tgz",
+      "integrity": "sha512-dBuNnQGKrJNfjunmXI2X7bl1gnMO4PwbNxrTzO1JvilODmL7WyyCtA+DYxe9XunLXmxmgzFIvKPQ6XRAQrr46Q==",
       "requires": {
         "nanoid": "^1.0.7"
       }
@@ -15634,25 +15643,31 @@
       }
     },
     "socketcluster-client": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/socketcluster-client/-/socketcluster-client-5.5.2.tgz",
-      "integrity": "sha1-nUNp4Oci/35V5UIsLUT1r+Gv8Sg=",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/socketcluster-client/-/socketcluster-client-13.0.1.tgz",
+      "integrity": "sha512-hxiE2xz6mgaBlhXbtBa4POgWVEvIcjCoHzf5LTUVhI9IL8V2ltV3Ze8pQsi9egqTjSz4RHPfyrJ7BiETe5Kthw==",
       "requires": {
         "base-64": "0.1.0",
         "clone": "2.1.1",
+        "component-emitter": "1.2.1",
         "linked-list": "0.1.0",
         "querystring": "0.2.0",
-        "sc-channel": "~1.0.6",
-        "sc-emitter": "~1.1.0",
-        "sc-errors": "~1.3.0",
-        "sc-formatter": "~3.0.0",
-        "ws": "3.0.0"
+        "sc-channel": "^1.2.0",
+        "sc-errors": "^1.4.0",
+        "sc-formatter": "^3.0.1",
+        "uuid": "3.2.1",
+        "ws": "5.1.1"
       },
       "dependencies": {
         "clone": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
           "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+        },
+        "uuid": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
         }
       }
     },
@@ -15676,9 +15691,9 @@
       }
     },
     "sockjs-client": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
-      "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.5.tgz",
+      "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
       "requires": {
         "debug": "^2.6.6",
         "eventsource": "0.1.6",
@@ -16231,15 +16246,14 @@
       "dev": true
     },
     "styled-components": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.3.3.tgz",
-      "integrity": "sha1-CecCBVqxH3qOq4IpscDQuFUJVoY=",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.4.2.tgz",
+      "integrity": "sha512-eTmIiWstyDLccHZAyp+aCPirlkTvYiHlYGgWQxOYDv8Ko0o6mfnDo0+DnUnKinO8NzAfQXEDP7Bh0qlazwJgrw==",
       "requires": {
         "buffer": "^5.0.3",
         "css-to-react-native": "^2.0.3",
         "fbjs": "^0.8.16",
         "hoist-non-react-statics": "^2.5.0",
-        "is-plain-object": "^2.0.1",
         "prop-types": "^15.5.4",
         "react-is": "^16.3.1",
         "stylis": "^3.5.0",
@@ -16248,9 +16262,9 @@
       },
       "dependencies": {
         "buffer": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
-          "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.0.tgz",
+          "integrity": "sha512-nUJyfChH7PMJy75eRDCCKtszSEFokUNXC1hNVSe+o+VdcgvDPLs20k3v8UXI8ruRYAJiYtyRea8mYyqPxoHWDw==",
           "requires": {
             "base64-js": "^1.0.2",
             "ieee754": "^1.1.4"
@@ -16967,9 +16981,9 @@
       "dev": true
     },
     "stylelint-processor-styled-components": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/stylelint-processor-styled-components/-/stylelint-processor-styled-components-1.3.1.tgz",
-      "integrity": "sha512-VXBNuEabP3n+k952riZ/2GUXqR54MdZ8chlOEA3J/n54CWy+tH9NhFsgF4AvZmr/QX1ys1PCoD4Ef3z7GKqmjA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/stylelint-processor-styled-components/-/stylelint-processor-styled-components-1.3.2.tgz",
+      "integrity": "sha512-EGzSSBFgQtiNCNfizjNz9LbU7Tebrt5JXxhJvORd/nDJgRp9zJqBEdDfIupsPUdWxW0SwkfrIuwz7iU+AQSz7w==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.0.0-beta.40",
@@ -18031,9 +18045,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
-      "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "requires": {
         "querystringify": "^2.0.0",
         "requires-port": "^1.0.0"
@@ -19002,19 +19016,11 @@
       }
     },
     "ws": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.0.0.tgz",
-      "integrity": "sha1-mN2wAFbIOQy3Ued4h4hJf5kQO2w=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.1.1.tgz",
+      "integrity": "sha512-bOusvpCb09TOBLbpMKszd45WKC2KPtxiyiHanv+H2DE3Az+1db5a/L7sVJZVDPUC1Br8f0SKRr1KjLpD1U/IAw==",
       "requires": {
-        "safe-buffer": "~5.0.1",
-        "ultron": "~1.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
-        }
+        "async-limiter": "~1.0.0"
       }
     },
     "x-is-array": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/ryanwiemer/gatsby-starter-gcn",
   "author": "Ryan Wiemer <ryan@ryanwiemer.com>",
   "dependencies": {
+    "@andrew-codes/gatsby-plugin-elasticlunr-search": "^1.0.4",
     "chalk": "^2.4.1",
     "contentful-import": "^7.2.0",
     "gatsby": "^1.9.272",
@@ -29,6 +30,8 @@
     "lodash": "^4.17.10",
     "path": "^0.12.7",
     "prismjs": "^1.15.0",
+    "prop-types": "^15.6.2",
+    "qs": "^6.5.2",
     "react-helmet": "^5.2.0",
     "styled-components": "^3.4.2",
     "whatwg-fetch": "^2.0.4"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Ryan Wiemer <ryan@ryanwiemer.com>",
   "dependencies": {
     "chalk": "^2.4.1",
-    "contentful-import": "^7.0.2",
+    "contentful-import": "^7.2.0",
     "gatsby": "^1.9.272",
     "gatsby-image": "^1.0.54",
     "gatsby-link": "^1.6.44",
@@ -25,12 +25,12 @@
     "gatsby-source-contentful": "^1.3.54",
     "gatsby-source-filesystem": "^1.5.39",
     "gatsby-transformer-remark": "^1.7.44",
-    "inquirer": "^6.0.0",
+    "inquirer": "^6.1.0",
     "lodash": "^4.17.10",
     "path": "^0.12.7",
     "prismjs": "^1.15.0",
     "react-helmet": "^5.2.0",
-    "styled-components": "^3.3.2",
+    "styled-components": "^3.4.2",
     "whatwg-fetch": "^2.0.4"
   },
   "keywords": [
@@ -52,11 +52,11 @@
   "devDependencies": {
     "eslint": "^4.19.1",
     "eslint-config-gatsby-standard": "^1.2.2",
-    "prettier": "^1.13.5",
+    "prettier": "^1.14.2",
     "stylelint": "9.3.0",
     "stylelint-config-prettier": "^3.2.0",
     "stylelint-config-standard": "^18.2.0",
     "stylelint-config-styled-components": "^0.1.1",
-    "stylelint-processor-styled-components": "^1.3.1"
+    "stylelint-processor-styled-components": "^1.3.2"
   }
 }

--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -1,6 +1,5 @@
-import React, { Component } from 'react'
+import React from 'react'
 import styled from 'styled-components'
-import Card from './Card'
 
 const List = styled.ul`
   display: flex;
@@ -13,33 +12,8 @@ const List = styled.ul`
   }
 `
 
-class CardList extends Component {
-  render() {
-    const { posts } = this.props
-    return (
-      <div>
-        <List>
-          {posts
-            .filter(
-              ({ node }) =>
-                !this.props.results ||
-                this.props.results.length === 0 ||
-                this.props.results.filter(hit => hit.id === node.id).length > 0
-            )
-            .map(({ node: post }, index) => (
-              <Card
-                key={post.id}
-                slug={post.slug}
-                image={post.heroImage}
-                title={post.title}
-                date={post.publishDate}
-                excerpt={post.body}
-              />
-            ))}
-        </List>
-      </div>
-    )
-  }
+const CardList = props => {
+  return <List>{props.children}</List>
 }
 
 export default CardList

--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { Component } from 'react'
 import styled from 'styled-components'
+import Card from './Card'
 
 const List = styled.ul`
   display: flex;
@@ -12,8 +13,33 @@ const List = styled.ul`
   }
 `
 
-const CardList = props => {
-  return <List>{props.children}</List>
+class CardList extends Component {
+  render() {
+    const { posts } = this.props
+    return (
+      <div>
+        <List>
+          {posts
+            .filter(
+              ({ node }) =>
+                !this.props.results ||
+                this.props.results.length === 0 ||
+                this.props.results.filter(hit => hit.id === node.id).length > 0
+            )
+            .map(({ node: post }, index) => (
+              <Card
+                key={post.id}
+                slug={post.slug}
+                image={post.heroImage}
+                title={post.title}
+                date={post.publishDate}
+                excerpt={post.body}
+              />
+            ))}
+        </List>
+      </div>
+    )
+  }
 }
 
 export default CardList

--- a/src/components/PageTitle.js
+++ b/src/components/PageTitle.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import styled, { css } from 'styled-components'
 
 const sharedStyles = css`
@@ -30,9 +29,3 @@ export const PageTitleSmall = styled.h2`
   font-size: 2em;
   margin: 1rem 0 2rem 0;
 `
-
-// const PageTitle = props => {
-//   return <Title small={props.small}>{props.children}</Title>
-// }
-//
-// export default PageTitle

--- a/src/components/PageTitle.js
+++ b/src/components/PageTitle.js
@@ -2,12 +2,9 @@ import React from 'react'
 import styled, { css } from 'styled-components'
 
 const sharedStyles = css`
-  font-size: ${props => (props.small ? '2em' : '2.35em')};
   text-transform: capitalize;
   font-weight: 600;
   text-align: center;
-  margin: 0 0 3rem 0;
-  margin: ${props => (props.small ? '1rem 0 2rem 0' : '0 0 3rem 0')};
   line-height: 1.2;
   span {
     margin: 0 0 0 0.25em;

--- a/src/components/PageTitle.js
+++ b/src/components/PageTitle.js
@@ -1,13 +1,13 @@
 import React from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
-const Title = styled.h1`
-  font-size: ${props => (props.small ? '2em' : '3em')};
+const sharedStyles = css`
+  font-size: ${props => (props.small ? '2em' : '2.35em')};
   text-transform: capitalize;
   font-weight: 600;
   text-align: center;
   margin: 0 0 3rem 0;
-  margin: ${props => (props.small ? '1rem 0 4rem 0' : '0 0 3rem 0')};
+  margin: ${props => (props.small ? '1rem 0 2rem 0' : '0 0 3rem 0')};
   line-height: 1.2;
   span {
     margin: 0 0 0 0.25em;
@@ -21,8 +21,21 @@ const Title = styled.h1`
   }
 `
 
-const PageTitle = props => {
-  return <Title small={props.small}>{props.children}</Title>
-}
-
+const PageTitle = styled.h1`
+  ${sharedStyles};
+  font-size: 2.35em;
+  margin: 0 0 3rem 0;
+`
 export default PageTitle
+
+export const PageTitleSmall = styled.h2`
+  ${sharedStyles};
+  font-size: 2em;
+  margin: 1rem 0 2rem 0;
+`
+
+// const PageTitle = props => {
+//   return <Title small={props.small}>{props.children}</Title>
+// }
+//
+// export default PageTitle

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,0 +1,81 @@
+import PropTypes from 'prop-types'
+import qs from 'qs'
+import React, { Component } from 'react'
+import { Index } from 'elasticlunr'
+
+const getSearch = ({ location }) => {
+  if (!location) return ''
+  if (!location.search) return ''
+
+  const query = location.search.substring(1)
+  const parsed = qs.parse(query)
+  if (!parsed.q) return ''
+  return parsed.q
+}
+
+export default class Search extends Component {
+  constructor(props, context) {
+    super(props, context)
+
+    this.updateQuery = evt => {
+      const text = evt.target.value
+      const newQuery = qs.stringify({ q: text }, { format: 'RFC1738' })
+      const results = this.getHits(text)
+
+      this.setState(s => {
+        return {
+          ...s,
+          results,
+          query: text,
+        }
+      })
+      this.props.onSearch(text, results)
+    }
+
+    const query = getSearch(props)
+    this.state = {
+      query,
+      results: this.getHits(query),
+    }
+  }
+
+  createIndex() {
+    this.index = Index.load(this.props.data.index)
+  }
+
+  getHits(query) {
+    if (!query) return []
+
+    if (!this.index) this.createIndex()
+    const results = this.index.search(query)
+    return results.map(({ ref }) => this.index.documentStore.getDoc(ref))
+  }
+
+  render() {
+    const { query, results } = this.state
+
+    console.log(results)
+
+    return (
+      <div role="search">
+        <input
+          onChange={this.updateQuery}
+          placeholder="search posts"
+          style={{
+            width: '100%',
+          }}
+          type="search"
+          value={query}
+        />
+        {results.length} search results
+      </div>
+    )
+  }
+}
+
+Search.propTypes = {
+  data: PropTypes.shape({
+    index: PropTypes.object.isRequired,
+  }).isRequired,
+  onSearch: PropTypes.func.isRequired,
+}

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -38,6 +38,7 @@ export default class Search extends Component {
 
     this.updateQuery = evt => {
       const text = evt.target.value
+      // eslint-disable-next-line no-unused-vars
       const newQuery = qs.stringify({ q: text }, { format: 'RFC1738' })
       const results = this.getHits(text)
 

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -1,7 +1,26 @@
+import React, { Component } from 'react'
+import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import qs from 'qs'
-import React, { Component } from 'react'
 import { Index } from 'elasticlunr'
+
+const SearchBar = styled.input`
+  width: 100%;
+  text-align: center;
+  line-height: 1.6;
+
+  @media screen and (min-width: ${props => props.theme.responsive.small}) {
+    width: 30vw;
+    font-size: 1rem;
+    background: #2d2d2d;
+    color: white;
+    border: 1px solid ${props => props.theme.colors.secondary};
+    border-radius: 4px;
+    position: absolute;
+    top: 1rem;
+    margin-left: 35vw;
+  }
+`
 
 const getSearch = ({ location }) => {
   if (!location) return ''
@@ -58,16 +77,12 @@ export default class Search extends Component {
 
     return (
       <div role="search">
-        <input
+        <SearchBar
           onChange={this.updateQuery}
           placeholder="search posts"
-          style={{
-            width: '100%',
-          }}
           type="search"
           value={query}
         />
-        {results.length} search results
       </div>
     )
   }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import CardList from '../components/CardList'
+import Card from '../components/Card'
 import Container from '../components/Container'
 import PageTitle, { PageTitleSmall } from '../components/PageTitle'
 import SEO from '../components/SEO'
@@ -59,12 +60,28 @@ class IndexPage extends React.Component {
             </a>{' '}
             <span>🎉</span>
           </PageTitle>
-          <CardList
-            posts={posts}
-            searchData={data.siteSearchIndex}
-            results={results}
-          />
           <PageTitleSmall>{this.searchCount}</PageTitleSmall>
+
+          <CardList>
+            {posts
+              .filter(
+                ({ node }) =>
+                  !this.props.results ||
+                  this.props.results.length === 0 ||
+                  this.props.results.filter(hit => hit.id === node.id).length >
+                    0
+              )
+              .map(({ node: post }, index) => (
+                <Card
+                  key={post.id}
+                  slug={post.slug}
+                  image={post.heroImage}
+                  title={post.title}
+                  date={post.publishDate}
+                  excerpt={post.body}
+                />
+              ))}
+          </CardList>
         </Container>
       </div>
     )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import CardList from '../components/CardList'
 import Container from '../components/Container'
-import PageTitle from '../components/PageTitle'
+import PageTitle, { PageTitleSmall } from '../components/PageTitle'
 import SEO from '../components/SEO'
 import Search from '../components/Search'
 
@@ -21,13 +21,19 @@ class IndexPage extends React.Component {
     const results = this.state.results
     const data = this.props.data
     const posts = data.allContentfulPost.edges
+    var searchCount = 'All Posts'
+    if (results && results.length > 0) {
+      this.searchCount = results.length + ' search results'
+    } else {
+      this.searchCount = 'All Posts'
+    }
 
     return (
       <div>
         <SEO />
         <Search data={data.siteSearchIndex} onSearch={this.onSearch} />
         <Container>
-          <PageTitle small>
+          <PageTitle>
             <a
               href="https://www.gatsbyjs.org/"
               target="_blank"
@@ -58,6 +64,7 @@ class IndexPage extends React.Component {
             searchData={data.siteSearchIndex}
             results={results}
           />
+          <PageTitleSmall>{this.searchCount}</PageTitleSmall>
         </Container>
       </div>
     )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,61 +1,74 @@
 import React from 'react'
 import CardList from '../components/CardList'
-import Card from '../components/Card'
 import Container from '../components/Container'
 import PageTitle from '../components/PageTitle'
 import SEO from '../components/SEO'
+import Search from '../components/Search'
 
-const Index = ({ data }) => {
-  const posts = data.allContentfulPost.edges
+class IndexPage extends React.Component {
+  // Search properties
+  constructor(props) {
+    super(props)
+    this.state = { results: null }
+    this.onSearch = this.onSearch.bind(this)
+  }
 
-  return (
-    <div>
-      <SEO />
-      <Container>
-        <PageTitle small>
-          <a
-            href="https://www.gatsbyjs.org/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Gatsby
-          </a>,{' '}
-          <a
-            href="https://www.contentful.com/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Contentful
-          </a>{' '}
-          and{' '}
-          <a
-            href="https://www.netlify.com/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Netlify
-          </a>{' '}
-          <span>🎉</span>
-        </PageTitle>
-        <CardList>
-          {posts.map(({ node: post }) => (
-            <Card
-              key={post.id}
-              slug={post.slug}
-              image={post.heroImage}
-              title={post.title}
-              date={post.publishDate}
-              excerpt={post.body}
-            />
-          ))}
-        </CardList>
-      </Container>
-    </div>
-  )
+  onSearch(text, results) {
+    this.setState({ results: results })
+  }
+
+  render() {
+    const results = this.state.results
+    const data = this.props.data
+    const posts = data.allContentfulPost.edges
+
+    return (
+      <div>
+        <SEO />
+        <Search data={data.siteSearchIndex} onSearch={this.onSearch} />
+        <Container>
+          <PageTitle small>
+            <a
+              href="https://www.gatsbyjs.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Gatsby
+            </a>
+            ,{' '}
+            <a
+              href="https://www.contentful.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Contentful
+            </a>{' '}
+            and{' '}
+            <a
+              href="https://www.netlify.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Netlify
+            </a>{' '}
+            <span>🎉</span>
+          </PageTitle>
+          <CardList
+            posts={posts}
+            searchData={data.siteSearchIndex}
+            results={results}
+          />
+        </Container>
+      </div>
+    )
+  }
 }
 
 export const query = graphql`
   query indexQuery {
+    siteSearchIndex {
+      index
+    }
     allContentfulPost(
       limit: 1000
       sort: { fields: [publishDate], order: DESC }
@@ -84,4 +97,4 @@ export const query = graphql`
   }
 `
 
-export default Index
+export default IndexPage

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,9 +24,13 @@ class IndexPage extends React.Component {
     const posts = data.allContentfulPost.edges
     var searchCount = 'All Posts'
     if (results && results.length > 0) {
-      this.searchCount = results.length + ' search results'
+      if (results.length > 1) {
+        searchCount = results.length + ' Search Results'
+      } else {
+        searchCount = results.length + ' Search Result'
+      }
     } else {
-      this.searchCount = 'All Posts'
+      searchCount = 'All Posts'
     }
 
     return (
@@ -60,16 +64,15 @@ class IndexPage extends React.Component {
             </a>{' '}
             <span>🎉</span>
           </PageTitle>
-          <PageTitleSmall>{this.searchCount}</PageTitleSmall>
+          <PageTitleSmall>{searchCount}</PageTitleSmall>
 
           <CardList>
             {posts
               .filter(
                 ({ node }) =>
-                  !this.props.results ||
-                  this.props.results.length === 0 ||
-                  this.props.results.filter(hit => hit.id === node.id).length >
-                    0
+                  !results ||
+                  results.length === 0 ||
+                  results.filter(hit => hit.id === node.id).length > 0
               )
               .map(({ node: post }, index) => (
                 <Card

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -4,7 +4,7 @@ import Helmet from 'react-helmet'
 import config from '../utils/siteConfig'
 import Card from '../components/Card'
 import CardList from '../components/CardList'
-import PageTitle from '../components/PageTitle'
+import PageTitleSmall from '../components/PageTitle'
 import Container from '../components/Container'
 
 const TagTemplate = ({ data }) => {
@@ -24,7 +24,11 @@ const TagTemplate = ({ data }) => {
       </Helmet>
 
       <Container>
-        <PageTitle small>Tag: &ldquo;{title}&rdquo;</PageTitle>
+        <PageTitleSmall>
+          Tag: &ldquo;
+          {title}
+          &rdquo;
+        </PageTitleSmall>
 
         <CardList>
           {posts.map(post => (


### PR DESCRIPTION
This PR adds client-side search functionality. A title search index is built by Gatsby and used to filter the results. It looks rather nice with the card layout.

The searchbar has been added to the index page, which functions as an index of all posts but also can be filtered with the search field. For projects with less than 10,000 pages, a simple and lightweight client-side search functionality seems preferrable to an API based service. This has the added benefit of functioning when the client is offline.