### PR TITLE
Add ?no-cache=1 to Form submit handler

### DIFF
--- a/src/components/ContactForm.js
+++ b/src/components/ContactForm.js
@@ -170,7 +170,7 @@ class ContactForm extends React.Component {
   }
 
   handleSubmit = event => {
-    fetch('/', {
+    fetch('/contact?no-cache=1', {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: encode({ 'form-name': 'contact', ...this.state }),


### PR DESCRIPTION
With the latest version of gatsby-plugin-offline, most pages are served from the service worker so they can work offline. To prevent the service worker from handling form submissions, add ?no-cache=1 to the URL. 

```
fetch("/contact?no-cache=1", {
  "body": encode({ 'form-name': 'contact', ...this.state })
});
```

See this issue for more details: https://github.com/gatsbyjs/gatsby/issues/7997