### PR TITLE
fix some bug in cretePages

### DIFF
--- a/src/gatsby/node/createPages.js
+++ b/src/gatsby/node/createPages.js
@@ -56,7 +56,7 @@ module.exports = async ({ graphql, actions }) => {
     paginate({
       createPage,
       component: path.resolve(`./src/templates/tag.js`),
-      items: tag.node.post,
+      items: tag.node.post || [],
       itemsPerPage: config.siteMetadata.postsPerPage,
       pathPrefix: `tag/${tag.node.slug}`,
       context: {


### PR DESCRIPTION
hello)
during creating conten in contentful i run into mistake in createPages. 
gatsby-awesome-paginate accepts object. Key items of these object should be array, but if tag not have field post an error accurs. Thank)